### PR TITLE
Add code input for number props

### DIFF
--- a/apps/vscode/src/extension/editor/document.ts
+++ b/apps/vscode/src/extension/editor/document.ts
@@ -5,15 +5,8 @@
  * see this files license find the nearest LICENSE file up the source tree.
  */
 import { type Mutation } from "@triplex/server";
+import { toJSONString } from "@triplex/lib";
 import * as vscode from "vscode";
-
-function toJSONString(value: unknown): string {
-  const str = JSON.stringify(value, (_k, v) =>
-    v === undefined ? "__UNDEFINED__" : v,
-  );
-
-  return str.replaceAll('"__UNDEFINED__"', "undefined");
-}
 
 export class TriplexDocument implements vscode.CustomDocument {
   private _onDidChange = new vscode.EventEmitter<{

--- a/packages/@triplex/editor-next/src/features/panels/inputs.tsx
+++ b/packages/@triplex/editor-next/src/features/panels/inputs.tsx
@@ -6,6 +6,7 @@
  */
 import {
   CheckIcon,
+  CodeIcon,
   ExclamationTriangleIcon,
   SwitchIcon,
 } from "@radix-ui/react-icons";
@@ -16,7 +17,7 @@ import {
   BooleanInput,
   ColorInput,
   LiteralUnionInput,
-  NumberInput,
+  NumberOrExpressionInput,
   resolveDefaultValue,
   StringInput,
   TupleInputNext,
@@ -126,7 +127,7 @@ export const renderPropInputs: RenderInputs = ({
     const persistedValue = "value" in prop.prop ? prop.prop.value : undefined;
 
     return (
-      <NumberInput
+      <NumberOrExpressionInput
         {...prop.prop.tags}
         actionId="scene_controls"
         defaultValue={resolveDefaultValue(prop.prop, "number")}
@@ -138,7 +139,7 @@ export const renderPropInputs: RenderInputs = ({
         pointerMode="capture"
         required={prop.prop.required}
       >
-        {({ ref, ...props }, { isActive }) => (
+        {({ ref, ...props }, { isActive, mode, shouldFocus, toggle }) => (
           <>
             <Label
               description={prop.prop.description}
@@ -147,19 +148,33 @@ export const renderPropInputs: RenderInputs = ({
             >
               {prop.prop.name}
             </Label>
-            <input
-              {...props}
-              aria-label={prop.prop.label}
-              className={cn([
-                !isActive && "invalid:border-danger",
-                "text-input border-input focus:border-selected bg-input placeholder:text-input-placeholder mb-1 h-[26px] w-full cursor-col-resize rounded-sm border px-[9px] [color-scheme:light_dark] [font-variant-numeric:tabular-nums] focus:cursor-text focus:outline-none",
-              ])}
-              ref={ref}
-              type="number"
-            />
+            <div className="mb-1 flex gap-1">
+              <input
+                {...props}
+                aria-label={prop.prop.label}
+                autoFocus={shouldFocus}
+                className={cn([
+                  !isActive && "invalid:border-danger",
+                  "text-input border-input focus:border-selected bg-input placeholder:text-input-placeholder mb-1 h-[26px] w-full cursor-col-resize rounded-sm border px-[9px] [color-scheme:light_dark] [font-variant-numeric:tabular-nums] focus:cursor-text focus:outline-none",
+                ])}
+                ref={ref}
+                type={mode === "number" ? "number" : "text"}
+              />
+              <IconButton
+                actionId="contextpanel_input_number_expression_toggle"
+                icon={CodeIcon}
+                label={
+                  mode === "number"
+                    ? "Switch to expression"
+                    : "Switch to number"
+                }
+                onClick={toggle}
+                spacing="spacious"
+              />
+            </div>
           </>
         )}
-      </NumberInput>
+      </NumberOrExpressionInput>
     );
   }
 

--- a/packages/@triplex/server/src/ast/__tests__/__mocks__/prop-expression.tsx
+++ b/packages/@triplex/server/src/ast/__tests__/__mocks__/prop-expression.tsx
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2022—present Michael Dougall. All rights reserved.
+ *
+ * This repository utilizes multiple licenses across different directories. To
+ * see this files license find the nearest LICENSE file up the source tree.
+ */
+import { memo } from "react";
+
+const Box = () => {
+  const pi = Math.PI;
+  return (
+    <mesh
+      position={[Math.sqrt(2), Math.sqrt(2), Math.sqrt(2)]}
+      rotateX={Math.PI / 2}
+      rotateY={pi / 2}
+    >
+      <boxGeometry args={[1, 1, 1]} />
+      <meshStandardMaterial color="pink" />
+    </mesh>
+  );
+};
+
+export default memo(Box);

--- a/packages/@triplex/server/src/ast/__tests__/type-infer.test.ts
+++ b/packages/@triplex/server/src/ast/__tests__/type-infer.test.ts
@@ -1201,4 +1201,37 @@ describe("type infer", () => {
         ]
       `);
   });
+  it("should evaluate expressions", () => {
+    const project = _createProject({
+      tsConfigFilePath: join(__dirname, "__mocks__/tsconfig.json"),
+    });
+    const sourceFile = project.addSourceFileAtPath(
+      join(__dirname, "__mocks__/prop-expression.tsx"),
+    );
+    const sceneObject = getJsxElementAt(sourceFile, 12, 5);
+    if (!sceneObject) {
+      throw new Error("not found");
+    }
+
+    const { props } = getJsxElementPropTypes(sceneObject);
+    const rotateXProp = props.find((prop) => prop.name === "rotateX");
+    expect(rotateXProp).toEqual(
+      expect.objectContaining({
+        value: "Math.PI / 2",
+        valueKind: "number",
+      }),
+    );
+    const rotateYProp = props.find((prop) => prop.name === "rotateY");
+    expect(rotateYProp).toEqual(
+      expect.objectContaining({
+        valueKind: "unhandled",
+      }),
+    );
+    const positionProp = props.find((prop) => prop.name === "position");
+    expect(positionProp).toEqual(
+      expect.objectContaining({
+        value: ["Math.sqrt(2)", "Math.sqrt(2)", "Math.sqrt(2)"],
+      }),
+    );
+  });
 });

--- a/packages/@triplex/server/src/ast/type-infer.ts
+++ b/packages/@triplex/server/src/ast/type-infer.ts
@@ -4,6 +4,7 @@
  * This repository utilizes multiple licenses across different directories. To
  * see this files license find the nearest LICENSE file up the source tree.
  */
+import { evaluateNumericalExpression } from "@triplex/lib/math";
 import {
   type AttributeValue,
   type DeclaredProp,
@@ -462,6 +463,10 @@ export function resolveExpressionValue(
 
   if (Node.isNumericLiteral(expression)) {
     return { kind: "number", value: Number(expression.getLiteralText()) };
+  }
+
+  if (expression && evaluateNumericalExpression(expression.getText())) {
+    return { kind: "number", value: expression.getText() };
   }
 
   if (Node.isPrefixUnaryExpression(expression)) {

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -29,6 +29,11 @@
       "module": "./src/log.ts",
       "default": "./src/log.ts"
     },
+    "./math": {
+      "types": "./src/math.ts",
+      "module": "./src/math.ts",
+      "default": "./src/math.ts"
+    },
     "./node": {
       "types": "./src/node.ts",
       "module": "./src/node.ts",

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -5,7 +5,11 @@
  * see this files license find the nearest LICENSE file up the source tree.
  */
 export { cn } from "./tw-merge";
-export { toJSONString } from "./string";
+export {
+  toJSONString,
+  type RawCodeExpression,
+  isRawCodeExpression,
+} from "./string";
 export { useEvent } from "./use-event";
 export { type Accelerator, onKeyDown, blockInputPropagation } from "./keyboard";
 export {

--- a/packages/lib/src/math.ts
+++ b/packages/lib/src/math.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2022—present Michael Dougall. All rights reserved.
+ *
+ * This repository utilizes multiple licenses across different directories. To
+ * see this files license find the nearest LICENSE file up the source tree.
+ */
+export function evaluateNumericalExpression(expression: string): number | null {
+  try {
+    const func = new Function(`return ${expression}`);
+    const result = func();
+
+    if (
+      typeof result === "number" &&
+      !Number.isNaN(result) &&
+      Number.isFinite(result)
+    ) {
+      return result;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/lib/src/string.ts
+++ b/packages/lib/src/string.ts
@@ -6,12 +6,36 @@
  */
 import { type CSSProperties } from "react";
 
-export function toJSONString(value: unknown): string {
-  const str = JSON.stringify(value, (_k, v) =>
-    v === undefined ? "__UNDEFINED__" : v,
-  );
+export interface RawCodeExpression {
+  __expr: string;
+}
 
-  return str.replaceAll('"__UNDEFINED__"', "undefined");
+export function isRawCodeExpression(
+  value: unknown,
+): value is RawCodeExpression {
+  return Boolean(value && typeof value === "object" && "__expr" in value);
+}
+
+export function toJSONString(value: unknown): string {
+  // Handle RawCodeExpression at the root level first
+  if (isRawCodeExpression(value)) {
+    return value.__expr;
+  }
+
+  const str = JSON.stringify(value, (_k, v) => {
+    if (v === undefined) {
+      return "__UNDEFINED__";
+    }
+    // Handle raw code expressions in nested values
+    if (isRawCodeExpression(v)) {
+      return `__EXPR__${v.__expr}__EXPR__`;
+    }
+    return v;
+  });
+
+  return str
+    .replaceAll('"__UNDEFINED__"', "undefined")
+    .replaceAll(/"__EXPR__(.*?)__EXPR__"/g, "$1");
 }
 
 export function kebabCase(str: string): string {

--- a/packages/renderer/src/features/scene-element/use-temporary-props.tsx
+++ b/packages/renderer/src/features/scene-element/use-temporary-props.tsx
@@ -6,12 +6,22 @@
  */
 
 import { compose, on, type RendererElementProps } from "@triplex/bridge/client";
+import { isRawCodeExpression } from "@triplex/lib";
 import { fg } from "@triplex/lib/fg";
+import { evaluateNumericalExpression } from "@triplex/lib/math";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 function useForceRender() {
   const [, setState] = useState(0);
   return useCallback(() => setState((prev) => prev + 1), []);
+}
+
+function unwrapPropValue(value: unknown): unknown {
+  if (isRawCodeExpression(value)) {
+    const evaluated = evaluateNumericalExpression(value.__expr);
+    return evaluated !== null ? evaluated : value;
+  }
+  return value;
 }
 
 export function useTemporaryProps(
@@ -40,8 +50,10 @@ export function useTemporaryProps(
         }
       }),
       on("request-set-element-prop", (data) => {
+        const propValue = unwrapPropValue(data.propValue);
+
         if (data.astPath === meta.astPath && fg("selection_ast_path")) {
-          intermediateProps.current[data.propName] = data.propValue;
+          intermediateProps.current[data.propName] = propValue;
           forceRender();
         } else if (
           "column" in data &&
@@ -49,7 +61,7 @@ export function useTemporaryProps(
           data.line === meta.line &&
           data.path === meta.path
         ) {
-          intermediateProps.current[data.propName] = data.propValue;
+          intermediateProps.current[data.propName] = propValue;
           forceRender();
         }
       }),

--- a/packages/ux/src/inputs/index.tsx
+++ b/packages/ux/src/inputs/index.tsx
@@ -8,6 +8,7 @@ export { BooleanInput } from "./boolean-input";
 export { ColorInput } from "./color-input";
 export { LiteralUnionInput } from "./literal-union-input";
 export { NumberInput } from "./number-input";
+export { NumberOrExpressionInput } from "./number-or-expression-input";
 export { PropInput } from "./prop-input";
 export { StringInput } from "./string-input";
 export { TupleInput } from "./tuple-input";

--- a/packages/ux/src/inputs/number-or-expression-input.tsx
+++ b/packages/ux/src/inputs/number-or-expression-input.tsx
@@ -1,0 +1,191 @@
+/**
+ * Copyright (c) 2022—present Michael Dougall. All rights reserved.
+ *
+ * This repository utilizes multiple licenses across different directories. To
+ * see this files license find the nearest LICENSE file up the source tree.
+ */
+import { type RawCodeExpression } from "@triplex/lib";
+import { evaluateNumericalExpression } from "@triplex/lib/math";
+import { useCallback, useState } from "react";
+import { type ActionIdSafe } from "../telemetry";
+import { NumberInput } from "./number-input";
+import { StringInput } from "./string-input";
+import { type RenderInput } from "./types";
+
+type Mode = "number" | "expression";
+
+interface NumberOrExpressionInputProps {
+  actionId: ActionIdSafe;
+  children: RenderInput<
+    {
+      defaultValue: number | string | undefined;
+      max?: number;
+      min?: number;
+      placeholder?: string;
+    },
+    HTMLInputElement,
+    {
+      clear: () => void;
+      isActive?: boolean;
+      mode: Mode;
+      shouldFocus: boolean;
+      toggle: () => void;
+    }
+  >;
+  defaultValue?: number;
+  label?: string;
+  max?: number;
+  min?: number;
+  name: string;
+  onChange: (value: number | string | undefined) => void;
+  onConfirm: (value: number | string | RawCodeExpression | undefined) => void;
+  persistedValue?: number | string;
+  pointerMode?: "capture" | "lock";
+  required?: boolean;
+  step?: number;
+  testId?: string;
+  transformValue?: {
+    in: (value: number | undefined) => number | undefined;
+    out: (value: number | undefined) => number | undefined;
+  };
+}
+
+/**
+ * A number input that can toggle between numeric input mode and code input
+ * mode. In expression mode, users can enter mathematical expressions like
+ * "Math.PI / 2" or "Math.sqrt(2)"
+ */
+export function NumberOrExpressionInput({
+  actionId,
+  children,
+  defaultValue,
+  label,
+  max,
+  min,
+  name,
+  onChange,
+  onConfirm,
+  persistedValue,
+  pointerMode = "lock",
+  required,
+  step,
+  testId,
+  transformValue,
+}: NumberOrExpressionInputProps) {
+  const getInitialMode = (): Mode => {
+    if (typeof persistedValue === "string") {
+      return "expression";
+    }
+    return "number";
+  };
+
+  const [mode, setMode] = useState<Mode>(getInitialMode);
+  const [shouldFocus, setShouldFocus] = useState(false);
+
+  const handleExpressionChange = useCallback(
+    (value: string | undefined) => {
+      if (value === undefined) {
+        onChange(undefined);
+        return;
+      }
+
+      // For live preview, pass the evaluated number
+      const evaluated = evaluateNumericalExpression(value);
+      if (evaluated !== null) {
+        onChange(evaluated);
+      }
+    },
+    [onChange],
+  );
+
+  const handleExpressionConfirm = useCallback(
+    (value: string | undefined) => {
+      if (value === undefined) {
+        onConfirm(undefined);
+        return;
+      }
+
+      // For saving, wrap the expression in a RawCodeExpression because we don't want it to be interpreted as a regular string
+      const evaluated = evaluateNumericalExpression(value);
+      if (evaluated !== null) {
+        onConfirm({ __expr: value });
+      }
+    },
+    [onConfirm],
+  );
+
+  const toggleMode = useCallback(() => {
+    setMode((prevMode) => (prevMode === "number" ? "expression" : "number"));
+    setShouldFocus(true);
+  }, []);
+
+  const handleClear = useCallback(() => {
+    onChange(undefined);
+    onConfirm(undefined);
+  }, [onChange, onConfirm]);
+
+  if (mode === "number") {
+    return (
+      <NumberInput
+        actionId={actionId}
+        defaultValue={defaultValue}
+        label={label}
+        max={max}
+        min={min}
+        name={name}
+        onChange={onChange}
+        onConfirm={onConfirm}
+        persistedValue={
+          typeof persistedValue === "number" ? persistedValue : undefined
+        }
+        pointerMode={pointerMode}
+        required={required}
+        step={step}
+        testId={testId}
+        transformValue={transformValue}
+      >
+        {(inputProps, inputActions) =>
+          children(inputProps, {
+            clear: handleClear,
+            isActive: inputActions.isActive,
+            mode,
+            shouldFocus,
+            toggle: toggleMode,
+          })
+        }
+      </NumberInput>
+    );
+  }
+
+  const expressionPersistedValue =
+    typeof persistedValue === "string"
+      ? persistedValue
+      : typeof persistedValue === "number"
+        ? String(persistedValue)
+        : undefined;
+
+  return (
+    <StringInput
+      actionId={actionId}
+      defaultValue={expressionPersistedValue}
+      label={label}
+      name={name}
+      onChange={handleExpressionChange}
+      onConfirm={handleExpressionConfirm}
+      persistedValue={
+        typeof persistedValue === "string" ? persistedValue : undefined
+      }
+      required={required}
+    >
+      {(inputProps) =>
+        children(inputProps, {
+          clear: handleClear,
+          isActive: false,
+          mode,
+          shouldFocus,
+          toggle: toggleMode,
+        })
+      }
+    </StringInput>
+  );
+}


### PR DESCRIPTION
Experimenting on this issue https://github.com/pmndrs/triplex/issues/254

This PR aims to improve the regular number input (as seen for the `position`, `rotation`, `scale` props) by adding a toggle to allow the user to input simple code expressions.
In this context, a valid expression is an expression that can be resolved in isolation, eg. `2 + 2`, `Math.PI / 2`, `Math.sqrt(2)` and so on. If a prop contains an identifier from an external variable (`myVariable * 2`), it then falls under the standard unhandled category.

Recommended review path:
- [Code parsing mock](https://github.com/pmndrs/triplex/pull/364/files#diff-8e921cc0217ba6362da7792112cc73a5b15278d7b692e76e64712ba54ef42d33R13) and [test](https://github.com/pmndrs/triplex/pull/364/files#diff-734f637f98761b9037db9404ff41ebc1ecad32972248d81127165c630525e13aR1218)
- [Expression parsing implementation](https://github.com/pmndrs/triplex/pull/364/files#diff-bc1c2b932b78d43219240634c46529d4fc40be25be1f582643e1bd6646fe2653R7) and [addition to type-infer](https://github.com/pmndrs/triplex/pull/364/files#diff-80afa48478ebd880f0e4942e6850ca70ec89d2905d73fde37548c7ec7895dd0dR468)
- [NumberOrExpressionInput component](https://github.com/pmndrs/triplex/pull/364/files#diff-c84f69210707095f8d19744f411c6784b5afcbb0f1511415fa4f6d4802dc9f7fR58) that wraps a `NumberInput` and a `StringInput` to allow switching between number and code inputs.
- [NumberOrExpressionInput implementation](https://github.com/pmndrs/triplex/pull/364/files#diff-ed96993813246d239c074cc78f2810cb7ef0bde821198d6264409e934b3b066bR130) with the code toggle button
- [String utilities](https://github.com/pmndrs/triplex/pull/364/files#diff-9398d1584d6038cbb18557ecd13069695cc9156b4d0084bed0bb0acf9b2da713R9) : just like we don't want `undefined` to end up as a string in the code when saving, we want to save actual expressions in the code (`Math.PI` instead of `"Math.PI"`)
- [Prop unwrapping](https://github.com/pmndrs/triplex/pull/364/files#diff-7edf0e7ee3e1431e6c76a78ad0721e6e6650ab134a211cfa9d00ab07c9dd9407R53) to ensure the preview works correctly even with wrapped expressions

To be improved : there is no visible validation as of now, if an incorrect expression is saved, the prop value is silently replaced with `undefined`